### PR TITLE
Simplify the Plausible proxy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "html2canvas": "^1.4.1",
         "isomorphic-unfetch": "^3.1.0",
         "next": "^13.0.6",
-        "next-plausible": "^3.7.0",
+        "next-plausible": "^3.7.1",
         "next-sitemap": "^3.1.32",
         "random-weighted-choice": "^0.1.4",
         "react": "^18.2.0",
@@ -10353,9 +10353,9 @@
       }
     },
     "node_modules/next-plausible": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/next-plausible/-/next-plausible-3.7.0.tgz",
-      "integrity": "sha512-YQ/b+BcPIZHOsQPB+YkAAzP4l9oELt3qKazPYvuNr5WRHRDknpyIkge4hf6aeuM+Wg4sdxaY7DfbbAUZlgREuw==",
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/next-plausible/-/next-plausible-3.7.1.tgz",
+      "integrity": "sha512-I4WjbuXPfQ3ijbzOC1lv1GNx6TTV0ZevR6YYs5vGZIyMz0z4LuN68x08a+ag2XNb1yy9dA1NkwV2hPzbfx8Gtw==",
       "funding": {
         "url": "https://github.com/4lejandrito/next-plausible?sponsor=1"
       },
@@ -20981,9 +20981,9 @@
       }
     },
     "next-plausible": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/next-plausible/-/next-plausible-3.7.0.tgz",
-      "integrity": "sha512-YQ/b+BcPIZHOsQPB+YkAAzP4l9oELt3qKazPYvuNr5WRHRDknpyIkge4hf6aeuM+Wg4sdxaY7DfbbAUZlgREuw=="
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/next-plausible/-/next-plausible-3.7.1.tgz",
+      "integrity": "sha512-I4WjbuXPfQ3ijbzOC1lv1GNx6TTV0ZevR6YYs5vGZIyMz0z4LuN68x08a+ag2XNb1yy9dA1NkwV2hPzbfx8Gtw=="
     },
     "next-sitemap": {
       "version": "3.1.32",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "html2canvas": "^1.4.1",
     "isomorphic-unfetch": "^3.1.0",
     "next": "^13.0.6",
-    "next-plausible": "^3.7.0",
+    "next-plausible": "^3.7.1",
     "next-sitemap": "^3.1.32",
     "random-weighted-choice": "^0.1.4",
     "react": "^18.2.0",


### PR DESCRIPTION
Version 3.7.1 of `next-plausible` addressed the [caching issue](https://github.com/4lejandrito/next-plausible/issues/83#issuecomment-1399432942) of the proxied script, which means we no longer need to do the integration by hand and can now rely on `withPlausibleProxy`. Yay! ✨ 

